### PR TITLE
Add CORS handler

### DIFF
--- a/elephant_vending_machine/__init__.py
+++ b/elephant_vending_machine/__init__.py
@@ -5,8 +5,10 @@ module can import it safely and the __name__ variable will always
 resolve to the correct package.
 """
 from flask import Flask
+from flask_cors import CORS, cross_origin
 
 APP = Flask(__name__)
+CORS(APP)
 APP.config.update(
     REMOTE_HOSTS=['192.168.1.11', '192.168.1.12', '192.168.1.13'],
     REMOTE_HOST_USERNAME='pi',

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ codecov==2.0.15
 coverage==5.0.3
 docutils==0.16
 Flask==1.1.1
+Flask-Cors==3.0.8
 gunicorn==20.0.4
 idna==2.8
 imagesize==1.2.0


### PR DESCRIPTION
Right now, all requests from the front end are being blocked by CORS. Adding this handler will allow the front end to successfully call the back end. Resolves #27 