### PR TITLE
Fix repo badges

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: build
 
 on: [push]
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ OSU CSE 5911 Capstone Project: Elephant Vending Machine in coordination with Cin
 
 ![Python package](https://github.com/mknox1225/elephants_cse5911/workflows/Python%20package/badge.svg?branch=master)
 [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/Kalafut-organization/elephants_cse5911/blob/master/LICENSE.md)
-[![codecov](https://codecov.io/gh/Kalafut-organization/elephants_cse5911/branch/master/graph/badge.svg)](https://codecov.io/gh/Kalafut-organization/elephants_cse5911)
+[![codecov](https://codecov.io/gh/Kalafut-organization/elephant_vending_machine_backend/branch/master/graph/badge.svg)](https://codecov.io/gh/Kalafut-organization/elephant_vending_machine_backend)
 [![Documentation Status](https://readthedocs.org/projects/elephants-cse5911/badge/?version=latest)](https://elephants-cse5911.readthedocs.io/en/latest/?badge=latest)
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Elephant Vending Machine
 OSU CSE 5911 Capstone Project: Elephant Vending Machine in coordination with Cincinnati Zoo. Designed to facilitate automated behavioral psychology experiments.
 
-![Python package](https://github.com/mknox1225/elephants_cse5911/workflows/Python%20package/badge.svg?branch=master)
+[![build](https://github.com/Kalafut-organization/elephant_vending_machine_backend/workflows/build/badge.svg)](https://github.com/Kalafut-organization/elephant_vending_machine_backend/actions?query=workflow%3Abuild)
 [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/Kalafut-organization/elephants_cse5911/blob/master/LICENSE.md)
 [![codecov](https://codecov.io/gh/Kalafut-organization/elephant_vending_machine_backend/branch/master/graph/badge.svg)](https://codecov.io/gh/Kalafut-organization/elephant_vending_machine_backend)
 [![Documentation Status](https://readthedocs.org/projects/elephants-cse5911/badge/?version=latest)](https://elephants-cse5911.readthedocs.io/en/latest/?badge=latest)


### PR DESCRIPTION
I've updated the Codecov badge to use the new repo name which should resolve #32. I also changed the build action name to "build" so that the repo badge for the action shows "Build: passing" or "Build: failing" which is more descriptive in my opinion.